### PR TITLE
refs #3 - use official AWS SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ build: deps
 
 deps:
 	@echo "Downloading libraries..."
-	@$(GO) get github.com/mitchellh/goamz/aws
-	@$(GO) get github.com/mitchellh/goamz/ec2
-	@$(GO) get github.com/mitchellh/goamz/elb
+	@$(GO) get github.com/aws/aws-sdk-go/aws
+	@$(GO) get github.com/aws/aws-sdk-go/service/ec2
+	@$(GO) get github.com/aws/aws-sdk-go/service/elb
 	@$(GO) get github.com/mitchellh/multistep
 	@$(GO) get gopkg.in/alecthomas/kingpin.v1
 

--- a/create.go
+++ b/create.go
@@ -21,14 +21,15 @@ func (s *StepCreate) Run(state multistep.StateBag) multistep.StepAction {
 	security := state.Get("security").(string)
 	size := state.Get("size").(string)
   elbName := state.Get("elb").(string)
+  amount := state.Get("amount").(int)
 
 	// Spin up the instances.
 	options := &ec2.RunInstancesInput{
 		ImageID:        aws.String(ami),
 		KeyName:        aws.String(key),
 		InstanceType:   aws.String(size),
-		MinCount:       aws.Long(1),
-		MaxCount:       aws.Long(1),
+		MinCount:       aws.Long(int64(amount)),
+		MaxCount:       aws.Long(int64(amount)),
 		SecurityGroups: []*string{ aws.String(security) },
 	}
 	resp, err := clientEc2.RunInstances(options)

--- a/create.go
+++ b/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-  "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/mitchellh/multistep"
@@ -20,8 +20,8 @@ func (s *StepCreate) Run(state multistep.StateBag) multistep.StepAction {
 	key := state.Get("key").(string)
 	security := state.Get("security").(string)
 	size := state.Get("size").(string)
-  elbName := state.Get("elb").(string)
-  amount := state.Get("amount").(int)
+	elbName := state.Get("elb").(string)
+	amount := state.Get("amount").(int)
 
 	// Spin up the instances.
 	options := &ec2.RunInstancesInput{
@@ -38,22 +38,22 @@ func (s *StepCreate) Run(state multistep.StateBag) multistep.StepAction {
 	// Assign these to the correct ELB instance.
 	for _, instance := range resp.Instances {
 		fmt.Println("Creating: ", instance.InstanceID)
-    add := &elb.RegisterInstancesWithLoadBalancerInput{
-      Instances: []*elb.Instance{
-        { InstanceID: instance.InstanceID,
-        },
-      },
-      LoadBalancerName: aws.String(elbName),
-    }
-    _, err := clientElb.RegisterInstancesWithLoadBalancer(add)
+		add := &elb.RegisterInstancesWithLoadBalancerInput{
+			Instances: []*elb.Instance{
+				{ InstanceID: instance.InstanceID,
+			},
+		},
+		LoadBalancerName: aws.String(elbName),
+	}
+	_, err := clientElb.RegisterInstancesWithLoadBalancer(add)
 		Check(err)
 
 		// Tag the instances so we know what they are.
 		tags := buildTags(state.Get("tags").(string))
 		clientEc2.CreateTags(&ec2.CreateTagsInput{
-      Resources: []*string{instance.InstanceID},
-      Tags:      tags,
-    })
+			Resources: []*string{instance.InstanceID},
+			Tags:      tags,
+		})
 	}
 
 	return multistep.ActionContinue

--- a/destroy.go
+++ b/destroy.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-  "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/mitchellh/multistep"
@@ -15,26 +15,26 @@ func (s *StepDestroy) Run(state multistep.StateBag) multistep.StepAction {
 	clientElb := state.Get("client_elb").(*elb.ELB)
 	elbName := state.Get("elb").(string)
 
-  query := &elb.DescribeLoadBalancersInput{
-    LoadBalancerNames: []*string{
-      aws.String(elbName),
-    },
-  }
+	query := &elb.DescribeLoadBalancersInput{
+		LoadBalancerNames: []*string{
+			aws.String(elbName),
+		},
+	}
 
 	// Get all the load balancers from AWS's API.
 	bals, err := clientElb.DescribeLoadBalancers(query)
 	Check(err)
 
-  bal := bals.LoadBalancerDescriptions[0]
+	bal := bals.LoadBalancerDescriptions[0]
 	for _, instance := range bal.Instances {
 		fmt.Println("Removing: ", instance.InstanceID)
 
 		// Luckily we don't need to worry about deregistering from the Balancer first.
-    params := &ec2.TerminateInstancesInput{
-      InstanceIDs: []*string{
-        instance.InstanceID,
-      },
-    }
+		params := &ec2.TerminateInstancesInput{
+			InstanceIDs: []*string{
+				instance.InstanceID,
+			},
+		}
 		_, err := clientEc2.TerminateInstances(params)
 		Check(err)
 	}

--- a/destroy.go
+++ b/destroy.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-
-	"github.com/mitchellh/goamz/ec2"
-	"github.com/mitchellh/goamz/elb"
+  "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/mitchellh/multistep"
 )
 
@@ -13,23 +13,29 @@ type StepDestroy struct{}
 func (s *StepDestroy) Run(state multistep.StateBag) multistep.StepAction {
 	clientEc2 := state.Get("client_ec2").(*ec2.EC2)
 	clientElb := state.Get("client_elb").(*elb.ELB)
-	elbId := state.Get("elb").(string)
+	elbName := state.Get("elb").(string)
 
-	// This is the query that we will perform to find our load balancer.
-	query := &elb.DescribeLoadBalancer{
-		Names: []string{elbId},
-	}
+  query := &elb.DescribeLoadBalancersInput{
+    LoadBalancerNames: []*string{
+      aws.String(elbName),
+    },
+  }
 
 	// Get all the load balancers from AWS's API.
 	bals, err := clientElb.DescribeLoadBalancers(query)
 	Check(err)
 
-	bal := bals.LoadBalancers[0]
+  bal := bals.LoadBalancerDescriptions[0]
 	for _, instance := range bal.Instances {
-		fmt.Println("Removing: ", instance.InstanceId)
+		fmt.Println("Removing: ", instance.InstanceID)
 
 		// Luckily we don't need to worry about deregistering from the Balancer first.
-		_, err := clientEc2.TerminateInstances([]string{instance.InstanceId})
+    params := &ec2.TerminateInstancesInput{
+      InstanceIDs: []*string{
+        instance.InstanceID,
+      },
+    }
+		_, err := clientEc2.TerminateInstances(params)
 		Check(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-  "github.com/aws/aws-sdk-go/aws"
-  "github.com/aws/aws-sdk-go/service/ec2"
-  "github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/mitchellh/multistep"
 	"gopkg.in/alecthomas/kingpin.v1"
 )
@@ -26,8 +26,8 @@ func main() {
 	state := new(multistep.BasicStateBag)
 
 	// This allows us to share our client connections while in each of the steps.
-  state.Put("client_elb", elb.New(&aws.Config{Region: *region}))
-  state.Put("client_ec2", ec2.New(&aws.Config{Region: *region}))
+	state.Put("client_elb", elb.New(&aws.Config{Region: *region}))
+	state.Put("client_ec2", ec2.New(&aws.Config{Region: *region}))
 
 	// Standard configuration that has been passed in via the CLI.
 	state.Put("elb", *elbId)

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/mitchellh/goamz/aws"
-	"github.com/mitchellh/goamz/ec2"
-	"github.com/mitchellh/goamz/elb"
+  "github.com/aws/aws-sdk-go/aws"
+  "github.com/aws/aws-sdk-go/service/ec2"
+  "github.com/aws/aws-sdk-go/service/elb"
 	"github.com/mitchellh/multistep"
 	"gopkg.in/alecthomas/kingpin.v1"
 )
@@ -23,21 +23,18 @@ func main() {
 	kingpin.CommandLine.Help = "AWS deployment tools."
 	kingpin.Parse()
 
-	auth, err := aws.EnvAuth()
-	Check(err)
-
 	state := new(multistep.BasicStateBag)
 
 	// This allows us to share our client connections while in each of the steps.
-	state.Put("client_elb", elb.New(auth, aws.USWest2))
-	state.Put("client_ec2", ec2.New(auth, aws.USWest2))
+  state.Put("client_elb", elb.New(&aws.Config{Region: *region}))
+  state.Put("client_ec2", ec2.New(&aws.Config{Region: *region}))
 
 	// Standard configuration that has been passed in via the CLI.
 	state.Put("elb", *elbId)
 	state.Put("ami", *amiId)
 	state.Put("key", *key)
 	state.Put("size", *size)
-	state.Put("region", aws.Regions[*region])
+	state.Put("region", *region)
 	state.Put("security", *security)
 	state.Put("tags", *tags)
 


### PR DESCRIPTION
No functionality has been changed. Converted from using github.com/mitchellh/goamz/[aws|ec2|elb] to github.com/aws/aws-sdk-go/[aws|service/ec2|service/elb].
